### PR TITLE
Only require AWS account alias when name is unspecified

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,4 +1,6 @@
-data "aws_iam_account_alias" "current" {}
+data "aws_iam_account_alias" "current" {
+  count       = var.name == null ? 1 : 0
+}
 
 # Retrieve the Spot Account ID
 data "external" "account" {

--- a/locals.tf
+++ b/locals.tf
@@ -4,7 +4,7 @@ locals {
   organization_id = data.external.account.result["organization_id"]
   cloudProvider   = data.external.account.result["cloud_provider"]
   spotinst_token  = var.debug == true ? nonsensitive(var.spotinst_token) : var.spotinst_token
-  name            = var.name == null ? data.aws_iam_account_alias.current.account_alias : var.name
+  name            = var.name == null ? data.aws_iam_account_alias.current.0.account_alias : var.name
   random          = random_id.random_string.hex
 }
 


### PR DESCRIPTION
This bug is blocking me from being able to consume your module since I do not have an account alias, but I feel it should not be necessary since the value is only needed when name is unspecified.

# Jira Ticket

_Include a link to your Jira Ticket_
_Example: [JIRAISS-1234](https://spotinst.atlassian.net/browse/JIRAISS-1234)_

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_

# Checklist:
- [ ] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [ ] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have validated all the requirements in the Jira task were answered
- [ ] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 
